### PR TITLE
strutil.to_chunks(): Float chunk length

### DIFF
--- a/lib/acid/strutil.lua
+++ b/lib/acid/strutil.lua
@@ -5,6 +5,7 @@ local json = require( "cjson" )
 local table = table
 local string = string
 
+local math_floor = math.floor
 local string_sub = string.sub
 local table_insert = table.insert
 
@@ -160,8 +161,18 @@ function _M.to_chunks(s, n)
 
     local rst = {}
 
-    for i = 1, #s, n do
-        table_insert(rst, string_sub(s, i, i + n - 1))
+    local i = 1
+    local j
+    while true do
+        j = i + n - 1
+        local ii = math_floor(i)
+        local jj = math_floor(j)
+        table_insert(rst, string_sub(s, ii, jj))
+
+        i = j + 1
+        if math_floor(i) > #s then
+            break
+        end
     end
 
     return rst

--- a/lib/acid/unittest.lua
+++ b/lib/acid/unittest.lua
@@ -24,15 +24,18 @@ end
 
 local function _repr_lines(t, ref_table)
 
-    if t ~= nil then
-        if ref_table[t] ~= nil then
-            return {'...'}
-        end
+    local tp = type(t)
 
-        ref_table[t] = true
+    if t ~= nil then
+        if tp == 'table' or t == 'cdata' then
+            if ref_table[t] ~= nil then
+                return {'...'}
+            end
+
+            ref_table[t] = true
+        end
     end
 
-    local tp = type( t )
 
     if tp == 'string' then
         -- escape special chars

--- a/lib/test_strutil.lua
+++ b/lib/test_strutil.lua
@@ -205,13 +205,12 @@ function test.to_chunks_err(t)
     local cases = {
         {'a', 0},
         {'a', -1},
-        {'a', 0.3},
     }
 
     for ii, c in ipairs(cases) do
-        local inp, expected, desc = unpack(c)
+        local s, n = unpack(c)
 
-        t:err(function() strutil.to_chunks(inp) end,
+        t:err(function() strutil.to_chunks(s, n) end,
               tostring(ii) .. 'th: ' .. (desc or ''))
     end
 end
@@ -220,27 +219,31 @@ end
 function test.to_chunks(t)
 
     local cases    = {
-        {'',       1, {''},          'n = 0'},
-        {'a',      1, {'a'},         'n = 1'},
-        {'ab',     1, {'a','b'},     'n = 1:1'},
-        {'abc',    1, {'a','b','c'}, 'n = 1:1:1'},
-        {'',       3, {''},          'n = 3'},
-        {'a',      3, {'a'},         'n = 3'},
-        {'ab',     3, {'ab'},        'n = 3'},
-        {'abc',    3, {'abc'},       'n = 3'},
-        {'abcd',   3, {'abc','d'},   'n = 3:1'},
-        {'abcde',  3, {'abc','de'},  'n = 3:2'},
-        {'abcdef', 3, {'abc','def'}, 'n = 3:3'},
-        {'a c ef', 3, {'a c',' ef'}, 'n = 3:3, with space'},
+        {'',           1,         {''},                                      'n = 0'},
+        {'a',          1,         {'a'},                                     'n = 1'},
+        {'ab',         1,         {'a','b'},                                 'n = 1:1'},
+        {'abc',        1,         {'a','b','c'},                             'n = 1:1:1'},
+        {'',           3,         {''},                                      'n = 3'},
+        {'a',          3,         {'a'},                                     'n = 3'},
+        {'ab',         3,         {'ab'},                                    'n = 3'},
+        {'abc',        3,         {'abc'},                                   'n = 3'},
+        {'abcd',       3,         {'abc','d'},                               'n = 3:1'},
+        {'abcde',      3,         {'abc','de'},                              'n = 3:2'},
+        {'abcdef',     3,         {'abc','def'},                             'n = 3:3'},
+        {'a c ef',     3,         {'a c',' ef'},                             'n = 3:3, with space'},
+        {'abcdefghij', 1.333334,  {'a','b','cd','e','f','gh','i','j'},       'n = 1.333334'},
+        {'abcdef',     1.5,       {'a','bc','d','ef'},                       'n = 1.5'},
+        {'abcd',       0.333334,  {'','','a','','','b','','','c','','','d'}, 'n = 0.333334'},
 
     }
 
     for ii, c in ipairs(cases) do
         local s, n, expected, desc = unpack(c)
-
         dd('case: ', c)
 
         local rst = strutil.to_chunks(s, n)
+        dd('rst: ', rst)
+
         t:eqdict(expected, rst, tostring(ii) .. 'th: ' .. desc)
     end
 end


### PR DESCRIPTION
```
to_chunks('abcdefghij', 1.333334) --  {'a','b','cd','e','f','gh','i','j'}
```