### PR TITLE
add doc, minor refine

### DIFF
--- a/doc/acid/strutil.md
+++ b/doc/acid/strutil.md
@@ -9,7 +9,7 @@ This library is considered production ready.
 #   Description
 
 It provides with several often used string operation utilities.
-Most of them follows python-style.
+Most of them follow python-style.
 
 #   Synopsis
 
@@ -31,14 +31,14 @@ strutil.to_str(1,2,{10,a=1,20}) -- 12{10,20,a=1}
 `strutil.rsplit(str, pattern, opts)`
 
 Same as `strutil.split` except when `maxsplit` is specified,
-it starts splitting from right to left.
+it starts with splitting from right to left.
 
 ##  strutil.split
 
 **syntax**:
 `strutil.split(str, pattern, opts)`
 
-Split string `str` with separator `pattern`
+Split string `str` with a separator `pattern`
 
 ```
 strutil.split('a/b/c/d', '/', 2)     -- {'a', 'b', 'c/d'}
@@ -47,14 +47,14 @@ strutil.split('a/b/c/d', '/', 2)     -- {'a', 'b', 'c/d'}
 **arguments**:
 
 -   `str`:
-    is the string to split.
+    is the string to be split.
 
 -   `pattern`:
-    is separator in lua string pattern or a plain text string.
-    Depends on the third argument.
+    is a separator in lua string pattern or a plain text string,
+    depending on the third argument.
 
 -   `opts`:
-    is options to control behavior of split.
+    is an option to control the behavior of this function.
 
     The value of `opts` could be:
 
@@ -68,7 +68,7 @@ strutil.split('a/b/c/d', '/', 2)     -- {'a', 'b', 'c/d'}
 
         It splits `str` with plain text separator `pattern`.
 
-    -   number: plain text and limit max split times.
+    -   number: use plain text pattern and it limits max split times.
         `strutil.split(str, pattern, 3)`.
 
         It splits `str` with plain text `pattern` and splits at most 3 times.

--- a/doc/acid/strutil.md
+++ b/doc/acid/strutil.md
@@ -1,0 +1,93 @@
+#   Name
+
+acid.strutil
+
+#   Status
+
+This library is considered production ready.
+
+#   Description
+
+It provides with several often used string operation utilities.
+Most of them follows python-style.
+
+#   Synopsis
+
+```lua
+local strutil = require("acid.strutil")
+
+strutil.split('a/b/c', '/')     -- {'a', 'b', 'c'}
+
+
+-- convert series of data into human readable string.
+strutil.to_str(1,2,{10,a=1,20}) -- 12{10,20,a=1}
+```
+
+#   Methods
+
+##  strutil.rsplit
+
+**syntax**:
+`strutil.rsplit(str, pattern, opts)`
+
+Same as `strutil.split` except when `maxsplit` is specified,
+it starts splitting from right to left.
+
+##  strutil.split
+
+**syntax**:
+`strutil.split(str, pattern, opts)`
+
+Split string `str` with separator `pattern`
+
+```
+strutil.split('a/b/c/d', '/', 2)     -- {'a', 'b', 'c/d'}
+```
+
+**arguments**:
+
+-   `str`:
+    is the string to split.
+
+-   `pattern`:
+    is separator in lua string pattern or a plain text string.
+    Depends on the third argument.
+
+-   `opts`:
+    is options to control behavior of split.
+
+    The value of `opts` could be:
+
+    -   `nil`: lua string pattern.
+        `strutil.split(str, pattern)`
+
+        It splits `str` with lua string pattern `pattern`.
+
+    -   `true`: pattern is plain text.
+        `strutil.split(str, pattern, true)`
+
+        It splits `str` with plain text separator `pattern`.
+
+    -   number: plain text and limit max split times.
+        `strutil.split(str, pattern, 3)`.
+
+        It splits `str` with plain text `pattern` and splits at most 3 times.
+
+    -   table: options in a table. Valid option keys are `plain` and `maxsplit`.
+        `strutil.split(str, pattern, {plain=false, maxsplit=5})`
+
+        It splits `str` with lua string pattern and splits at most 5 times.
+
+**return**:
+a table of split strings.
+
+
+#   Author
+
+Zhang Yanpo (张炎泼) <drdr.xp@gmail.com>
+
+#   Copyright and License
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Zhang Yanpo (张炎泼) <drdr.xp@gmail.com>

--- a/lib/acid/strutil.lua
+++ b/lib/acid/strutil.lua
@@ -165,6 +165,8 @@ end
 
 function _M.strip( s, ptn )
 
+    -- TODO test
+
     if ptn == nil or ptn == "" then
         ptn = "%s"
     end
@@ -223,6 +225,7 @@ end
 
 
 function _M.replace(s, src, dst)
+    -- TODO test
     return table.concat(_M.split(s, src), dst)
 end
 
@@ -256,6 +259,7 @@ end
 
 
 function _M.fromhex(str)
+    -- TODO test
     return (str:gsub('..', function (cc)
         return string.char(tonumber(cc, 16))
     end))
@@ -263,6 +267,7 @@ end
 
 
 function _M.tohex(str)
+    -- TODO test
     return (str:gsub('.', function (c)
         return string.format('%02X', string.byte(c))
     end))

--- a/lib/acid/strutil.lua
+++ b/lib/acid/strutil.lua
@@ -9,6 +9,12 @@ local repr_str = repr.str
 
 local _M = { _VERSION = "0.1" }
 
+local fnmatch_wildcard_translate = {
+    ['*'] = '.*',
+    ['?'] = '.',
+    ['.'] = '[.]',
+}
+
 
 local function normalize_split_opts(opts)
 
@@ -230,31 +236,22 @@ function _M.replace(s, src, dst)
 end
 
 
-local function _parse_fnmatch_char(a1)
-    if a1 == "*" then
-        return ".*"
-    elseif a1 == "?" then
-        return "."
-    elseif a1 == "." then
-        return "[.]"
-    else
-        return a1
-    end
-end
-
-
 function _M.fnmatch(s, ptn)
-    local p = ptn
-    local p = p:gsub('([\\]*)(.)', function(a0, a1)
-        local l = #a0
+
+    ptn = ptn:gsub('([\\]*)(.)', function(backslashes, chr)
+
+        local l = #backslashes
+
         if l % 2 == 0 then
-            return string.rep('[\\]', l/2).._parse_fnmatch_char(a1)
+            -- even number of back slash: not an escape
+            return string.rep('[\\]', l/2) .. (fnmatch_wildcard_translate[chr] or chr)
         else
-            return string.rep('[\\]', (l-1)/2)..'['.. a1 ..']'
+            -- odd number of back slash: an escape of following char
+            return string.rep('[\\]', (l-1)/2)..'['.. chr ..']'
         end
     end)
 
-    return s:match(p) == s
+    return s:match(ptn) == s
 end
 
 

--- a/lib/test_strutil.lua
+++ b/lib/test_strutil.lua
@@ -269,6 +269,33 @@ function test.endswith(t)
     t:eq(false, s( 'ab', 'bc' ) )
 end
 
+
+function test.to_str(t)
+
+    -- simplified test. underlaying repr.str() has been tested in test_repr.lua
+
+    local cases = {
+        {{},                    ''                 },
+        {{1,2},                 '12'               },
+        {{1,2,{}},              '12{}'             },
+        {{1,2,{10,a=1,20}},     '12{10,20,a=1}'    },
+        {{1,2,nil,{10,a=1,20}}, '12nil{10,20,a=1}' },
+    }
+
+    for ii, c in ipairs(cases) do
+
+        local inp, expected, desc = t:unpack(c)
+        local msg = 'case: ' .. tostring(ii) .. '-th '
+        dd(msg, c)
+
+        local rst = strutil.to_str(unpack(inp))
+        dd('rst: ', rst)
+
+        t:eq(expected, rst, msg)
+    end
+end
+
+
 function test.rjust(t)
     local f = strutil.rjust
     t:eq( '.......abc', f( 'abc', 10, '.' ) )


### PR DESCRIPTION
      add test for strutil.to_str()
      add doc for strutil.split() and strutil.rsplit()
      refactor strutil.fnmatch(): use table to translate wildcard instead of a function