### PR TITLE
fix unittest:case_iter now support 1st arg to be nil.

### DIFF
--- a/lib/acid/unittest.lua
+++ b/lib/acid/unittest.lua
@@ -189,7 +189,13 @@ local testfuncs = {
                 case[n + 1] = case[n + 1] .. ': ' .. desc
             end
 
-            return unpack(case, 1, n + 1)
+            -- add index
+            local _case = {i}
+            for j = 1, n + 1 do
+                _case[j + 1] = case[j]
+            end
+
+            return unpack(_case, 1, n + 1 + 1)
         end
     end,
 
@@ -230,6 +236,8 @@ local testfuncs = {
 
     err = function ( self, func, mes )
         local ok, rst = pcall( func )
+        dd('ok: ', ok)
+        dd('error msg: ', rst)
         self:eq( false, ok, mes )
     end,
 
@@ -370,6 +378,7 @@ _M.dd = dd
 function _M.output(s)
     if ngx then
         ngx.say(s)
+        print(s)
     else
         print(s)
     end

--- a/lib/test_strutil.lua
+++ b/lib/test_strutil.lua
@@ -5,7 +5,7 @@ local dd = test.dd
 
 function test.split(t)
 
-    for str, ptn, expected, desc in t:case_iter(3, {
+    for i, str, ptn, expected, desc in t:case_iter(3, {
         {'',             '/',  {'' },                    'empty string'               },
         {'/',            '/',  {'', '' },                'single pattern'             },
         {'//',           '/',  {'', '', '' },            'dual pattern'               },
@@ -38,7 +38,7 @@ end
 
 function test.split_maxsplit(t)
 
-    for str, ptn, maxsplit, expected, desc in t:case_iter(4, {
+    for i, str, ptn, maxsplit, expected, desc in t:case_iter(4, {
         {'',      '/', nil, {''}          },
         {'',      '/', -1,  {''}          },
         {'',      '/', 0,   {''}          },
@@ -75,7 +75,7 @@ end
 
 function test.right_n_split(t)
 
-    for str, ptn, frm, n, expected, desc in t:case_iter(5, {
+    for i, str, ptn, frm, n, expected, desc in t:case_iter(5, {
         {'',           '/', 1,  -1,  {0, {}               } },
         {'',           '/', 1,  0,   {0, {}               } },
         {'',           '/', 1,  1,   {0, {}               } },
@@ -105,7 +105,7 @@ end
 
 function test.rsplit(t)
 
-    for str, ptn, plain, maxsplit, expected, desc in t:case_iter(5, {
+    for i, str, ptn, plain, maxsplit, expected, desc in t:case_iter(5, {
         {'',           '/',     true,  nil, {''}                },
         {'',           '/',     true,  -1,  {''}                },
         {'',           '/',     true,  0,   {''}                },
@@ -233,7 +233,7 @@ end
 
 function test.strip(t)
 
-    for str, ptn, expected, desc in t:case_iter(3, {
+    for i, str, ptn, expected, desc in t:case_iter(3, {
         {'',               nil,            ''      },
         {'',               '',             ''      },
         {'abc',            nil,            'abc'   },
@@ -262,7 +262,7 @@ end
 
 function test.startswith(t)
 
-    for str, prefix, start, expected, desc in t:case_iter(4, {
+    for i, str, prefix, start, expected, desc in t:case_iter(4, {
         { '',      '',               nil, true,  },
         { 'a',     '',               nil, true,  },
         { 'a',     'b',              nil, false, },
@@ -288,7 +288,7 @@ end
 
 function test.endswith(t)
 
-    for str, suffix, expected, desc in t:case_iter(3, {
+    for i, str, suffix, expected, desc in t:case_iter(3, {
         { '',   '',                true,  },
         { 'a',  '',                true,  },
         { 'a',  'b',               false, },
@@ -311,7 +311,7 @@ function test.to_str(t)
 
     -- simplified test. underlaying repr.str() has been tested in test_repr.lua
 
-    for inp, expected, desc in t:case_iter(2, {
+    for i, inp, expected, desc in t:case_iter(2, {
         {{},                    ''                 },
         {{1,2},                 '12'               },
         {{1,2,{}},              '12{}'             },
@@ -329,7 +329,7 @@ end
 
 function test.placeholder(t)
 
-    for val, ph, float_fmt, expected, desc in t:case_iter(4, {
+    for i, val, ph, float_fmt, expected, desc in t:case_iter(4, {
         {nil,     nil,  nil,    '-'     },
         {'',      nil,  nil,    '-'     },
         {nil,     'xx', nil,    'xx'    },
@@ -434,7 +434,7 @@ end
 
 function test.fromhex_err(t)
 
-    for str, desc in t:case_iter(1, {
+    for i, str, desc in t:case_iter(1, {
         {1                        },
         {true                     },
         {false                    },
@@ -452,7 +452,7 @@ end
 
 function test.fromhex(t)
 
-    for str, expected, desc in t:case_iter(2, {
+    for i, str, expected, desc in t:case_iter(2, {
         {'',     ''         },
         {'00',   '\x00'     },
         {'0011', '\x00\x11' },
@@ -468,7 +468,7 @@ end
 
 function test.tohex_err(t)
 
-    for str, desc in t:case_iter(2, {
+    for i, str, desc in t:case_iter(2, {
         {1     },
         {true  },
         {false },
@@ -483,7 +483,7 @@ end
 
 function test.tohex(t)
 
-    for inp, expected, desc in t:case_iter(2, {
+    for i, inp, expected, desc in t:case_iter(2, {
         {'',         ''      },
         {'\x00',     '00',   },
         {'\x00\x11', '0011', },
@@ -499,7 +499,7 @@ end
 
 function test.to_chunks_err(t)
 
-    for s, n, desc in t:case_iter(3, {
+    for i, s, n, desc in t:case_iter(3, {
         {'a', 0},
         {'a', -1},
     }) do
@@ -512,7 +512,7 @@ end
 
 function test.to_chunks(t)
 
-    for s, n, expected, desc in t:case_iter(3, {
+    for i, s, n, expected, desc in t:case_iter(3, {
         {'',           1,         {''},                                      'n = 0'},
         {'a',          1,         {'a'},                                     'n = 1'},
         {'ab',         1,         {'a','b'},                                 'n = 1:1'},

--- a/lib/test_time.lua
+++ b/lib/test_time.lua
@@ -5,7 +5,7 @@ local dd = test.dd
 
 function test.parse(t)
 
-    for fmtkey, date, expected, err_code, desc in t:case_iter(4, {
+    for i, fmtkey, date, expected, err_code, desc in t:case_iter(4, {
         {'isobase',        '20170726T061317Z',              1501049597, nil           },
         {'iso',            '2017-07-26T06:13:17.000Z',      1501049597, nil           },
         {'utc',            'Wed, 26 Jul 2017 06:13:17 UTC', 1501049597, nil           },
@@ -35,7 +35,7 @@ end
 
 function test.format(t)
 
-    for fmtkey, ts, expected, err_code, desc in t:case_iter(4, {
+    for i, fmtkey, ts, expected, err_code, desc in t:case_iter(4, {
         {'iso',            1501049597, '2017-07-26T06:13:17.000Z',      nil             },
         {'utc',            1501049597, 'Wed, 26 Jul 2017 06:13:17 UTC', nil             },
         {'std',            1501049597, '2017-07-26 14:13:17',           nil             },
@@ -68,7 +68,7 @@ end
 
 function test.to_sec(t)
 
-    for ts, expected, err_code, desc in t:case_iter(3, {
+    for i, ts, expected, err_code, desc in t:case_iter(3, {
         {'1499850242',                            1499850242, nil             },
         {'1499850242' .. '000',                   1499850242, nil             },
         {'1499850242' .. '000' .. '000',          1499850242, nil             },


### PR DESCRIPTION
If the first arg of a case is nil, case_iter() finishes iteration becase
lua treat a `nil` to be an end-of-iteration symbol.
Now case_iter always return an index value `i` to avoid this issue.

Other fix: output debug message during unittest to `error.log`.