### PR TITLE
fix an error in parsing invalid strings

### DIFF
--- a/lib/acid/guid.lua
+++ b/lib/acid/guid.lua
@@ -71,7 +71,7 @@ function _M.new(shared_guid, shared_lock, len_ts, len_seq, len_mid)
         key_exptime = key_exptime,
 
         id_pattern = string.format("%%%dd%%0%dd%%0%dd", len_ts, len_seq, len_mid),
-        parse_pattern = string.format('([0-9]{%d})([0-9]{%d})([0-9]{%d})',
+        parse_pattern = string.format('^([0-9]{%d})([0-9]{%d})([0-9]{%d})$',
             len_ts, len_seq, len_mid),
     }
 

--- a/lib/test_guid.lua
+++ b/lib/test_guid.lua
@@ -89,8 +89,13 @@ function test.parse(t)
         {'1505375219371999999', 1505375219371, 99,  9999, nil         },
         {nil,                   nil,           nil, nil, 'NotString'  },
         {1505375219371000000,   nil,           nil, nil, 'NotString'  },
-        {'1505375219371',       nil,           nil, nil, 'InvalidGuid'},
+        {{1, 2, 3},             nil,           nil, nil, 'NotString'  },
+        {function() end,        nil,           nil, nil, 'NotString'  },
+        {true,                  nil,           nil, nil, 'NotString'  },
         {'abcdef',              nil,           nil, nil, 'InvalidGuid'},
+        {string.rep('f', 19),   nil,           nil, nil, 'InvalidGuid'},
+        {string.rep('1', 18),   nil,           nil, nil, 'InvalidGuid'},
+        {string.rep('1', 20),   nil,           nil, nil, 'InvalidGuid'},
     }) do
 
         local res, err, err_msg = obj:parse(guid_str)


### PR DESCRIPTION
修复guid.parse()的错误，当解析超过规定长度的字符串时，应该返回一个error