### PR TITLE
log pcall error in unittest.lua

### DIFF
--- a/lib/acid/unittest.lua
+++ b/lib/acid/unittest.lua
@@ -391,7 +391,12 @@ function _M.ngx_test_modules(module_names, opts)
 
     local ok, err = pcall(_test_modules, module_names)
     if not ok then
-        ngx.log(ngx.ERR, 'failed to run _test_modules: ' .. err)
+        local errmsg = 'failed to run _test_modules: ' .. err
+        if ngx ~= nil then
+            ngx.log(ngx.ERR, errmsg)
+        else
+            print(errmsg)
+        end
     end
 end
 

--- a/lib/acid/unittest.lua
+++ b/lib/acid/unittest.lua
@@ -391,8 +391,7 @@ function _M.ngx_test_modules(module_names, opts)
 
     local ok, err = pcall(_test_modules, module_names)
     if not ok then
-        local errmsg = 'failed to run _test_modules: ' .. err
-        _M.output(errmsg)
+        _M.output('failed to run _test_modules: ' .. err)
     end
 end
 

--- a/lib/acid/unittest.lua
+++ b/lib/acid/unittest.lua
@@ -389,7 +389,10 @@ function _M.ngx_test_modules(module_names, opts)
 
     _M.debug = opts.debug or false
 
-    pcall(_test_modules, module_names)
+    local ok, err = pcall(_test_modules, module_names)
+    if not ok then
+        ngx.log(ngx.ERR, 'failed to run _test_modules: ' .. err)
+    end
 end
 
 

--- a/lib/acid/unittest.lua
+++ b/lib/acid/unittest.lua
@@ -392,11 +392,7 @@ function _M.ngx_test_modules(module_names, opts)
     local ok, err = pcall(_test_modules, module_names)
     if not ok then
         local errmsg = 'failed to run _test_modules: ' .. err
-        if ngx ~= nil then
-            ngx.log(ngx.ERR, errmsg)
-        else
-            print(errmsg)
-        end
+        _M.output(errmsg)
     end
 end
 


### PR DESCRIPTION
不打印日志的话，好像看不到_test_modules函数里面程序出现异常的日志信息