### PR TITLE
counter: use probability as a second optional arg to replace timeout

### DIFF
--- a/doc/acid/counter.md
+++ b/doc/acid/counter.md
@@ -61,7 +61,7 @@ print(c:get('foo')) -- high probability 0
 ##  acid.counter.new
 
 **syntax**:
-`acid.counter:new(storage, least_tps, timeout)`
+`acid.counter:new(storage, least_tps, probability)`
 
 **arguments**:
 
@@ -73,11 +73,12 @@ print(c:get('foo')) -- high probability 0
     specifies times per second threshold to record.
     If an event happens not frequent enough it won't be record.
 
--   `timeout`:
-    optional to specify the timeout time of records in storage.
+-   `probability`:
+    optional to specify the probability to records in storage.
 
-    By default it is `0.01` second, and the probability to record a event is
-    calculated by: `p = 1 / timeout / least_tps`.
+    By default it is `0.01`, thus only `1%` of the events are recorded.
+    and the timeout of record is calculated by:
+    `timeout = 1 / probability / least_tps`.
 
 **return**:
 a counter instance.

--- a/lib/test_counter.lua
+++ b/lib/test_counter.lua
@@ -44,23 +44,20 @@ end
 function test.new(t)
     local sto = _new_storage()
     local c = counter:new(sto, 2, 0.5)
-    t:eq(0.5, c.timeout)
+    t:eq(1, c.timeout)
     t:eq(2, c.least_tps)
-    t:eq(1, c.probability)
+    t:eq(0.5, c.probability)
 
     local c = counter:new(sto, 200, 0.02)
-    t:eq(0.25, c.probability)
-
-    -- min value
-    local c = counter:new(sto, 2000 * 2000 * 2000)
-    t:eq(0.001 * 0.001, c.probability)
+    t:eq(0.25, c.timeout)
 end
 
 
 function test.more_than_least_tps(t)
     local sto = _new_storage()
 
-    local c = counter:new(sto, 1000)
+    local c = counter:new(sto, 1000, 0.1)
+    -- c.timeout = 0.01
 
     for _ = 0, 20 do
         ngx.sleep(1/1200)
@@ -78,8 +75,8 @@ end
 function test.less_than_least_tps(t)
     local sto = _new_storage()
 
-    local c = counter:new(sto, 1000)
-    -- c.probability = 0.1
+    local c = counter:new(sto, 1000, 0.1)
+    -- c.timeout = 0.01
 
     for _ = 0, 20 do
         c:incr('foo')


### PR DESCRIPTION
把counter的可选参数timeout去掉了. 替换成参数probability.

如果指定timeout, 来计算p, 会导致出现`p> 1`的情况, 用p计算timeout, 不会出现这种情况.