### PR TITLE
Lsl ngx abort pcall

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ It is meant to be a underlaying code base for building a distributed system.
 This package needs perl command `prove` to run unittest:
 
 ```
+# install in centos 7
+$ yum install -y perl-CPAN perl-Test-Harness
+
+```
+
+run test:
+
+```
 $ sudo cpan Test::Nginx
 
 # optional, setup nginx path:
@@ -72,7 +80,12 @@ $ export PATH=$PATH:/usr/local/Cellar/openresty/1.11.2.3/nginx/sbin
 
 # test all
 $ prove
+
+# test modules with verbose mode
+# prove t/ngx_abort_test.t t/ngx_abort.t -v
 ```
+
+check nginx.conf and logs used in test under `t/servroot/conf`, `t/servroot/logs`.
 
 
 # lua-poxos

--- a/lib/acid/ngx_abort.lua
+++ b/lib/acid/ngx_abort.lua
@@ -45,7 +45,10 @@ local function exec_callbacks()
         local cb_array = callbacks[index]
 
         for _, cb in ipairs(cb_array) do
-            cb.func(unpack(cb.args))
+            local ok, rst = pcall(cb.func, unpack(cb.args))
+            if not ok then
+                ngx.log(ngx.ERR, 'callback crash: ', rst)
+            end
         end
     end
 

--- a/t/ngx_abort_test.t
+++ b/t/ngx_abort_test.t
@@ -279,6 +279,10 @@ GET /t
             local ngx_abort = require("acid.ngx_abort")
 
             local a = 1
+            local cb_crash = function()
+                assert(false, "cb_crash, a is " .. tostring(a))
+            end
+
             local add = function(to_add)
                 a = a + to_add
                 ngx.log(ngx.INFO, "after add, a is ", a)
@@ -290,7 +294,21 @@ GET /t
             end
 
             local _, err, errmsg = ngx_abort.add_callback_with_opts(
+                    cb_crash, {position="last"})
+            if err ~= nil then
+                ngx.log(ngx.ERR, "add callback error")
+                return
+            end
+
+            local _, err, errmsg = ngx_abort.add_callback_with_opts(
                     multiply, {position="last"})
+            if err ~= nil then
+                ngx.log(ngx.ERR, "add callback error")
+                return
+            end
+
+            local _, err, errmsg = ngx_abort.add_callback_with_opts(
+                    cb_crash, {position=50})
             if err ~= nil then
                 ngx.log(ngx.ERR, "add callback error")
                 return
@@ -326,6 +344,8 @@ GET /t
 --- error_log eval
 [
     "after add, a is 2",
+    "cb_crash, a is 2",
     "after add, a is 4",
+    "cb_crash, a is 4",
     "after multiply, a is 8",
 ]


### PR DESCRIPTION
- use pcall to wrap callbacks in ngx_abort and add test
- more info to run test:  install cpan and prove,  nginx.conf and logs position